### PR TITLE
BUG: Fix required Python version in package setup

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ name = braintransform
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.8
 include_package_data = True
 install_requires =
     regex


### PR DESCRIPTION
Fix required Python version in package setup.

Fixes:
```
ERROR: Package 'braintransform' requires a different Python: 3.8.12 not in '==3.6'
```

raised in:
https://github.com/brainhackorg/braintransform/runs/5175901365?check_suite_focus=true#step:7:58