### PR TITLE
ENH: Remove unnecessary workflow steps

### DIFF
--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -12,7 +12,6 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: [3.8]
-        requires: ['minimal', 'latest']
 
     steps:
     - name: Check out repository
@@ -24,21 +23,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-
-    - name: Set min. dependencies
-      if: matrix.requires == 'minimal'
-      run: |
-        python -c "req = open('setup.cfg').read().replace('>', '=') ; open('setup.cfg', 'w').write(req)"
-
-    - name: Cache pip
-      uses: actions/cache@v2
-      id: cache
-      with:
-        path: ${{ env.pythonLocation }}
-        # Look to see if there is a cache hit for the corresponding requirements file
-        key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}
-        restore-keys: |
-          ${{ env.pythonLocation }}-
 
     - name: Install dependencies
       # if: steps.cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
Remove unnecessary workflow steps:
- Remove the unnecessary `minimal` version step: no required packages
have a greater than or equal to version specification. This also avoids
the weak substitution of the sign to make the workflow fail because a
different Python version is being required, i.e.:
```
ERROR: Package 'braintransform' requires a different Python: 3.8.12 not in '==3.8'
```
in
https://github.com/brainhackorg/braintransform/runs/5175935193?check_suite_focus=true#step:7:58
- Remove caching the pip installation: this might be useful when the
number of required packages is large. It also avoids needing to specify
a file for the hash (`requirements.txt` no longer exists).