### PR TITLE
ENH: Install `flake8` for development

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,12 +27,11 @@ scripts =
 
 [options.extras_require]
 testing =
+    flake8 == 3.7.9
     pytest == 5.3.*
     pytest-cov
     pytest-pep8
     pytest-xdist
     pytest_console_scripts
 dev =
-    flake8 == 3.9.2
-    flake8-docstrings == 1.6.0
     %(testing)s


### PR DESCRIPTION
Install `flake8` for development.

Fixes
```
/home/runner/work/_temp/ce560110-851d-4e53-92fc-94953f39c780.sh: line 3: flake8: command not found
```

raised in:
https://github.com/brainhackorg/braintransform/runs/5175981961?check_suite_focus=true#step:5:110

Take advantage of the commit to:
- Use the previously required package version.
- Remove the docstring checking package as it was not previously present.